### PR TITLE
USHIFT-6984 disable 5.0 brew rpm testing

### DIFF
--- a/ci-operator/config/openshift/microshift/openshift-microshift-release-5.0__periodics.yaml
+++ b/ci-operator/config/openshift/microshift/openshift-microshift-release-5.0__periodics.yaml
@@ -136,7 +136,7 @@ tests:
       SCENARIO_TYPE: bootc-periodics-el10
     workflow: openshift-microshift-e2e-metal-tests
 - as: e2e-aws-tests-nightly
-  cron: 30 3 * * 1-5
+  cron: 0 0 31 2 *
   reporter_config:
     channel: '#microshift-alerts'
     job_states_to_report:
@@ -152,7 +152,7 @@ tests:
       SCENARIO_TYPE: periodics
     workflow: openshift-microshift-e2e-metal-tests
 - as: e2e-aws-tests-arm-nightly
-  cron: 30 3 * * 1-5
+  cron: 0 0 31 2 *
   reporter_config:
     channel: '#microshift-alerts'
     job_states_to_report:
@@ -244,7 +244,7 @@ tests:
       SUITE: ai-model-serving
     workflow: openshift-microshift-e2e-bare-metal-tests
 - as: e2e-aws-tests-release-periodic
-  cron: 0 3 * * 0,2,4
+  cron: 0 0 31 2 *
   steps:
     cluster_profile: openshift-org-aws
     env:
@@ -254,7 +254,7 @@ tests:
       TEST_EXECUTION_TIMEOUT: 60m
     workflow: openshift-microshift-e2e-metal-tests
 - as: e2e-aws-tests-release-arm-periodic
-  cron: 0 3 * * 0,2,4
+  cron: 0 0 31 2 *
   steps:
     cluster_profile: openshift-org-aws
     env:

--- a/ci-operator/jobs/openshift/microshift/openshift-microshift-release-5.0-periodics.yaml
+++ b/ci-operator/jobs/openshift/microshift/openshift-microshift-release-5.0-periodics.yaml
@@ -456,7 +456,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build11
-  cron: 30 3 * * 1-5
+  cron: 0 0 31 2 *
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -1397,7 +1397,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build11
-  cron: 30 3 * * 1-5
+  cron: 0 0 31 2 *
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -1488,7 +1488,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build11
-  cron: 0 3 * * 0,2,4
+  cron: 0 0 31 2 *
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -1571,7 +1571,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build11
-  cron: 0 3 * * 0,2,4
+  cron: 0 0 31 2 *
   decorate: true
   decoration_config:
     skip_cloning: true


### PR DESCRIPTION
MicroShift's 5.0 brew rpms aren't yet available, so these jobs will fail perpetually. Disabling them for now to cut down noice.